### PR TITLE
anime episode numbering crash workaround, original language searches

### DIFF
--- a/api/shows.go
+++ b/api/shows.go
@@ -559,8 +559,17 @@ func showEpisodeLinks(showId int, seasonNumber int, episodeNumber int) ([]*bitto
 		return nil, errors.New("Unable to find season")
 	}
 
-	episode := season.Episodes[episodeNumber - 1]
-
+	var episode *tmdb.Episode
+	for _, epi := range season.Episodes {
+		if epi.EpisodeNumber == episodeNumber {
+			episode = epi
+			break
+		}
+	}
+	if episode == nil {
+		return nil, errors.New("Unable to find episode")
+	}
+			
 	showsLog.Infof("Resolved %d to %s", showId, show.Name)
 
 	searchers := providers.GetEpisodeSearchers()

--- a/providers/xbmc.go
+++ b/providers/xbmc.go
@@ -120,10 +120,11 @@ func NewAddonSearcher(addonId string) *AddonSearcher {
 
 func (as *AddonSearcher) GetMovieSearchObject(movie *tmdb.Movie) *MovieSearchObject {
 	year, _ := strconv.Atoi(strings.Split(movie.ReleaseDate, "-")[0])
-	title := movie.OriginalTitle
-	if title == "" {
-		title = movie.Title
+	title := movie.Title
+	if config.Get().UseOriginalTitle && movie.OriginalTitle != "" {
+		title = movie.OriginalTitle
 	}
+
 	sObject := &MovieSearchObject{
 		IMDBId: movie.IMDBId,
 		Title:  NormalizeTitle(title),
@@ -138,9 +139,9 @@ func (as *AddonSearcher) GetMovieSearchObject(movie *tmdb.Movie) *MovieSearchObj
 
 func (as *AddonSearcher) GetSeasonSearchObject(show *tmdb.Show, season *tmdb.Season) *SeasonSearchObject {
 	year, _ := strconv.Atoi(strings.Split(season.AirDate, "-")[0])
-	title := show.OriginalName
-	if title == "" {
-		title = show.Name
+	title := show.Name
+	if config.Get().UseOriginalTitle && show.OriginalName != "" {
+		title = show.OriginalName
 	}
 
 	return &SeasonSearchObject{
@@ -154,9 +155,9 @@ func (as *AddonSearcher) GetSeasonSearchObject(show *tmdb.Show, season *tmdb.Sea
 
 func (as *AddonSearcher) GetEpisodeSearchObject(show *tmdb.Show, episode *tmdb.Episode) *EpisodeSearchObject {
 	year, _ := strconv.Atoi(strings.Split(episode.AirDate, "-")[0])
-	title := show.OriginalName
-	if title == "" {
-		title = show.Name
+	title := show.Name
+	if config.Get().UseOriginalTitle && show.OriginalName != "" {
+		title = show.OriginalName
 	}
 
 	tvdbId := util.StrInterfaceToInt(show.ExternalIDs.TVDBID)

--- a/providers/xbmc.go
+++ b/providers/xbmc.go
@@ -164,7 +164,7 @@ func (as *AddonSearcher) GetEpisodeSearchObject(show *tmdb.Show, episode *tmdb.E
 
 	// Is this an Anime?
 	absoluteNumber := 0
-	if util.StrInterfaceToInt(show.ExternalIDs.TVDBID) > 0 {
+	if tvdbId > 0 {
 		countryIsJP := false
 		for _, country := range show.OriginCountry {
 			if country == "JP" {


### PR DESCRIPTION
Some shows (anime) number episodes incrementally without regard to season number. quasar was crashing trying to assign to non allocated memory space.
Other fix is for original language show/movie search even when you don't pick that from settings